### PR TITLE
CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,6 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     fetch_and_include(cmake/boost_fetch.cmake)
     fetch_and_include(cmake/boost_test.cmake)
 
-    boost_fetch(boostorg/assert TAG develop)
     boost_fetch(boostorg/config TAG develop)
     boost_fetch(boostorg/detail TAG develop)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(Boost::variant2 ALIAS boost_variant2)
 target_include_directories(boost_variant2 INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
 target_compile_features(boost_variant2 INTERFACE cxx_alias_templates cxx_variadic_templates cxx_decltype)
 
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+if(PROJECT_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 
     # --target check
 
@@ -36,6 +36,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     fetch_and_include(cmake/boost_fetch.cmake)
     fetch_and_include(cmake/boost_test.cmake)
 
+    # for variant2
     boost_fetch(boostorg/config TAG develop)
     boost_fetch(boostorg/detail TAG develop)
 
@@ -63,9 +64,13 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 
     #export(EXPORT ${PROJECT_NAME}Targets NAMESPACE Boost:: FILE ${PROJECT_NAME}Config.cmake)
 
-endif()
-
-if(COMMAND boost_test)
+    # for tests
+    boost_fetch(boostorg/assert TAG develop)
+    boost_fetch(boostorg/core TAG develop)
+    boost_fetch(boostorg/preprocessor TAG develop)
+    boost_fetch(boostorg/type_traits TAG develop)
+    boost_fetch(boostorg/static_assert TAG develop)
+    boost_fetch(boostorg/mp11 TAG develop)
 
     add_subdirectory(test)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,73 @@
+# Copyright 2018 Peter Dimov
+# Copyright 2019 Hans Dembinski
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.5)
+
+project(BoostVariant2 VERSION 1.71.0 LANGUAGES CXX)
+
+add_library(boost_variant2 INTERFACE)
+set_property(TARGET boost_variant2 PROPERTY EXPORT_NAME variant2)
+
+add_library(Boost::variant2 ALIAS boost_variant2)
+
+target_include_directories(boost_variant2 INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
+target_compile_features(boost_variant2 INTERFACE cxx_alias_templates cxx_variadic_templates cxx_decltype)
+
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+
+    # --target check
+
+    # `function` confuses FetchContent, sees empty CMAKE_CURRENT_LIST_DIR
+    macro(fetch_and_include name)
+
+        message(STATUS "Fetching ${name}")
+
+        file(DOWNLOAD
+            "https://raw.githubusercontent.com/boostorg/mincmake/master/${name}"
+            "${CMAKE_BINARY_DIR}/fetch_and_include/${name}"
+        )
+
+        include("${CMAKE_BINARY_DIR}/fetch_and_include/${name}")
+
+    endmacro()
+
+    fetch_and_include(cmake/boost_fetch.cmake)
+    fetch_and_include(cmake/boost_test.cmake)
+
+    boost_fetch(boostorg/assert TAG develop)
+    boost_fetch(boostorg/config TAG develop)
+    boost_fetch(boostorg/detail TAG develop)
+
+    enable_testing()
+    add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -C $<CONFIG>)
+
+    # --target install
+
+    set(CONFIG_INSTALL_DIR lib/cmake/${PROJECT_NAME}-${PROJECT_VERSION})
+
+    install(TARGETS boost_variant2 EXPORT ${PROJECT_NAME}Targets)
+    install(EXPORT ${PROJECT_NAME}Targets DESTINATION ${CONFIG_INSTALL_DIR} NAMESPACE Boost:: FILE ${PROJECT_NAME}Config.cmake)
+
+    install(DIRECTORY include/ DESTINATION include)
+
+    include(CMakePackageConfigHelpers)
+
+    # Variant2 is independent of 32/64, so this hack makes BoostMp11ConfigVersion.cmake skip the check
+    set(OLD_CMAKE_SIZEOF_VOID_P ${CMAKE_SIZEOF_VOID_P})
+    unset(CMAKE_SIZEOF_VOID_P)
+    write_basic_package_version_file("${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake" COMPATIBILITY AnyNewerVersion)
+    set(CMAKE_SIZEOF_VOID_P ${OLD_CMAKE_SIZEOF_VOID_P})
+
+    install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake" DESTINATION ${CONFIG_INSTALL_DIR})
+
+    #export(EXPORT ${PROJECT_NAME}Targets NAMESPACE Boost:: FILE ${PROJECT_NAME}Config.cmake)
+
+endif()
+
+if(COMMAND boost_test)
+
+    add_subdirectory(test)
+
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright 2018 Peter Dimov
+# Copyright 2019 Hans Dembinski
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+boost_test_jamfile(FILE Jamfile LIBRARIES Boost::variant2 Boost::core Boost::detail)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,4 +3,11 @@
 # Distributed under the Boost Software License, Version 1.0.
 # See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
 
-boost_test_jamfile(FILE Jamfile LIBRARIES Boost::variant2 Boost::core Boost::detail)
+boost_fetch(boostorg/assert TAG develop)
+boost_fetch(boostorg/core TAG develop)
+boost_fetch(boostorg/preprocessor TAG develop)
+boost_fetch(boostorg/type_traits TAG develop)
+boost_fetch(boostorg/static_assert TAG develop)
+boost_fetch(boostorg/mp11 TAG develop)
+
+boost_test_jamfile(FILE Jamfile LIBRARIES Boost::variant2 Boost::core Boost::detail Boost::assert Boost::preprocessor Boost::type_traits Boost::static_assert Boost::mp11)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,11 +3,4 @@
 # Distributed under the Boost Software License, Version 1.0.
 # See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
 
-boost_fetch(boostorg/assert TAG develop)
-boost_fetch(boostorg/core TAG develop)
-boost_fetch(boostorg/preprocessor TAG develop)
-boost_fetch(boostorg/type_traits TAG develop)
-boost_fetch(boostorg/static_assert TAG develop)
-boost_fetch(boostorg/mp11 TAG develop)
-
 boost_test_jamfile(FILE Jamfile LIBRARIES Boost::variant2 Boost::core Boost::detail Boost::assert Boost::preprocessor Boost::type_traits Boost::static_assert Boost::mp11)


### PR DESCRIPTION
To use variant2 in Boost.Histogram, CMake support is needed.

I copied the CMakeLists.txt from Mp11 and adapted it. variant2 itself has very few dependencies, but the tests add a lot of additional dependencies. When I boost_fetch variant2 from Boost.Histogram, variant2 also boost_fetch-es the dependencies for the tests, which are not needed then. I thought that the line `if (CMAKE_SOURCE_DIR STREQAL CMAKE_CURRENT_SOURCE_DIR)` was supposed to prevent this, but it doesn't. This also needs to be fixed in Mp11.