### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -7,9 +7,9 @@ import project ;
 
 project /boost/variant2
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/config//boost_config
-        <source>/boost/mp11//boost_mp11
+        <library>/boost/assert//boost_assert
+        <library>/boost/config//boost_config
+        <library>/boost/mp11//boost_mp11
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/variant2
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/variant2

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,22 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/variant2
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/config//boost_config
+        <source>/boost/mp11//boost_mp11
+        <include>include
+    ;
+
+explicit
+    [ alias boost_variant2 ]
+    [ alias all : boost_variant2 test ]
+    ;
+
+call-if : boost-library variant2
+    ;

--- a/build.jam
+++ b/build.jam
@@ -5,18 +5,21 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/config//boost_config
+    /boost/mp11//boost_mp11 ;
+
 project /boost/variant2
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/config//boost_config
-        <library>/boost/mp11//boost_mp11
         <include>include
     ;
 
 explicit
-    [ alias boost_variant2 ]
+    [ alias boost_variant2 : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_variant2 test ]
     ;
 
 call-if : boost-library variant2
     ;
+

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -16,9 +16,9 @@ project
     <warnings>extra
 
   : requirements
-    <source>/boost/config//boost_config
-    <source>/boost/container_hash//boost_container_hash
-    <source>/boost/core//boost_core
+    <library>/boost/config//boost_config
+    <library>/boost/container_hash//boost_container_hash
+    <library>/boost/core//boost_core
 
     <toolset>msvc:<warnings-as-errors>on
     <toolset>gcc:<warnings-as-errors>on

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -7,6 +7,7 @@
 #  http://www.boost.org/LICENSE_1_0.txt
 
 import testing ;
+import-search /boost/config/checks ;
 import config : requires ;
 
 project

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -7,7 +7,7 @@
 #  http://www.boost.org/LICENSE_1_0.txt
 
 import testing ;
-import ../../config/checks/config : requires ;
+import config : requires ;
 
 project
   : default-build
@@ -15,12 +15,16 @@ project
     <warnings>extra
 
   : requirements
+    <source>/boost/config//boost_config
+    <source>/boost/container_hash//boost_container_hash
+    <source>/boost/core//boost_core
 
     [ requires cxx11_variadic_templates cxx11_template_aliases cxx11_decltype cxx11_constexpr ]
 
     <toolset>msvc:<warnings-as-errors>on
     <toolset>gcc:<warnings-as-errors>on
     <toolset>clang:<warnings-as-errors>on
+
   ;
 
 run quick.cpp ;
@@ -127,7 +131,7 @@ run variant_visit_by_index.cpp ;
 run variant_ostream_insert.cpp ;
 run is_output_streamable.cpp ;
 
-local JSON = <library>/boost//json/<warnings>off "<toolset>msvc-14.0:<build>no" "<toolset>msvc-14.2:<cxxflags>-wd5104" "<undefined-sanitizer>norecover:<link>static" ;
+local JSON = <library>/boost/json//boost_json/<warnings>off "<toolset>msvc-14.0:<build>no" "<toolset>msvc-14.2:<cxxflags>-wd5104" "<undefined-sanitizer>norecover:<link>static" ;
 
 run variant_json_value_from.cpp : : : $(JSON) ;
 run variant_json_value_to.cpp : : : $(JSON) ;


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.